### PR TITLE
Update Telemetry package to reroute tracking to telemetry API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1964,9 +1964,9 @@
       }
     },
     "defer-to-connect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
-      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -2897,9 +2897,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/src/common/analytics.ts
+++ b/src/common/analytics.ts
@@ -1,5 +1,5 @@
 import * as applicationinsights from 'applicationinsights';
-import * as http from 'https';
+import * as got from 'got';
 
 const apiEndpointHostname = process.env.API_ENDPOINT_HOSTNAME!; // eslint-disable-line no-process-env
 const instrumentationKey = process.env.RESULT_INSTRUMENTATION_KEY!; // eslint-disable-line no-process-env
@@ -7,44 +7,23 @@ const instrumentationKey = process.env.RESULT_INSTRUMENTATION_KEY!; // eslint-di
 applicationinsights.setup(instrumentationKey).start();
 
 const appInsightsClient = applicationinsights.defaultClient;
-
-let options = {
+const options = {
     batchDelay: 15000,
-    defaultProperties: {},
+    defaultProperties: {}
 };
 let sendTimeout: any = null;
 let telemetryQueue: any = [];
 
 const post = async (data: any) => {
-    const reqOptions = {
-        hostname: apiEndpointHostname,
-        port: 80,
-        path: '/api/log',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': data.length
-        }
-    };
-
-    const req = http.request(reqOptions, (res) => {
-        console.log(`statusCode: ${res.statusCode}`)
-
-        res.on('data', (d) => {
-            console.log(`BODY: ${d}`)
+    try {
+        const response = await got.post(apiEndpointHostname, {
+            json: data
         });
 
-        res.on('end', () => {
-            console.log('No more data in response.');
-        });
-    });
-
-    req.on('error', (error) => {
-        console.error(error)
-    });
-
-    req.write(data);
-    req.end();
+        console.log(response.body);
+    } catch (error) {
+        console.log(error.response.body);
+    }
 };
 
 const sendTelemetry = async () => {

--- a/src/common/analytics.ts
+++ b/src/common/analytics.ts
@@ -6,12 +6,80 @@ applicationinsights.setup(instrumentationKey).start();
 
 const appInsightsClient = applicationinsights.defaultClient;
 
+const telemetryApiEndpoint = 'https://webhint-telemetry.azurewebsites.net/api/log';
+    let sendTimeout: any = null;
+    let telemetryQueue: any = [];
+    let options = {
+        batchDelay: 15000,
+        defaultProperties: {},
+    };
+
+const post = async (url: string, data: any) => {
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: data
+    });
+    return response;
+};
+
+const sendTelemetry = async () => {
+    if (sendTimeout) {
+        clearTimeout(sendTimeout);
+        sendTimeout = null;
+    }
+    const data = JSON.stringify({
+        data: telemetryQueue
+    });
+
+    telemetryQueue = [];
+    try {
+        post(telemetryApiEndpoint, data)
+            .then(response => {
+                if (response.status !== 200) {
+                    console.warn('Failed to send telemetry: ', status);
+                }
+            });
+    }
+    catch (err) {
+        console.warn('Failed to send telemetry: ', err);
+    }
+};
+
+const addToQueue = async (type: string, data: any) => {
+    telemetryQueue.push(
+        {
+            name: data.name,
+            properties: Object.assign(Object.assign({}, options.defaultProperties), data.properties),
+            ver: 2,
+            type: `${type}Data`
+        }
+    );
+    if (!options.batchDelay) {
+        await sendTelemetry();
+    }
+    else if (!sendTimeout) {
+        sendTimeout = setTimeout(sendTelemetry, options.batchDelay);
+    }
+};
+
+/**
+ * Send an event to webhint telemetry API.
+ * @param name - Event name.
+ * @param properties - Properties to track.
+ */
+export const trackEvent = async (name: string, properties: any) => {
+    await addToQueue('Event', { name, properties });
+};
+
 /**
  * Send an event to Application Insights.
  * @param name - Event name.
  * @param properties - Properties to track.
  */
-export const trackEvent = (name: string, properties: any = {}) => {
+export const addToAppInsights = (name: string, properties: any = {}) => {
     appInsightsClient.trackEvent({
         name,
         properties

--- a/src/common/analytics.ts
+++ b/src/common/analytics.ts
@@ -12,7 +12,7 @@ const options = {
     defaultProperties: {}
 };
 let sendTimeout: any = null;
-let telemetryQueue: any = [];
+const telemetryQueue: any = [];
 
 const post = async (data: any) => {
     try {
@@ -32,6 +32,7 @@ const sendTelemetry = async () => {
 
     try {
         const data = telemetryQueue.splice(0);
+
         await post(data);
     } catch (err) {
         console.warn('Failed to send telemetry: ', err);

--- a/src/common/analytics.ts
+++ b/src/common/analytics.ts
@@ -14,13 +14,13 @@ const options = {
 let sendTimeout: any = null;
 let telemetryQueue: any = [];
 
-const post = async (data: any) => {
+const post = async () => {
     try {
-        const response = await got.post(apiEndpointHostname, { json: data });
-
+        const response = await got.post(apiEndpointHostname, { json: telemetryQueue });
+        telemetryQueue = [];
         console.log(response.body);
     } catch (error) {
-        console.log(error.response.body);
+        console.warn(error.response.body);
     }
 };
 
@@ -29,11 +29,9 @@ const sendTelemetry = async () => {
         clearTimeout(sendTimeout);
         sendTimeout = null;
     }
-    const data = JSON.stringify({ data: telemetryQueue });
-
-    telemetryQueue = [];
+        telemetryQueue = [];
     try {
-        await post(data);
+        await post();
     } catch (err) {
         console.warn('Failed to send telemetry: ', err);
     }

--- a/src/common/analytics.ts
+++ b/src/common/analytics.ts
@@ -16,9 +16,7 @@ let telemetryQueue: any = [];
 
 const post = async (data: any) => {
     try {
-        const response = await got.post(apiEndpointHostname, {
-            json: data
-        });
+        const response = await got.post(apiEndpointHostname, { json: data });
 
         console.log(response.body);
     } catch (error) {
@@ -31,15 +29,12 @@ const sendTelemetry = async () => {
         clearTimeout(sendTimeout);
         sendTimeout = null;
     }
-    const data = JSON.stringify({
-        data: telemetryQueue
-    });
+    const data = JSON.stringify({ data: telemetryQueue });
 
     telemetryQueue = [];
     try {
         await post(data);
-    }
-    catch (err) {
+    } catch (err) {
         console.warn('Failed to send telemetry: ', err);
     }
 };
@@ -49,14 +44,13 @@ const pushToQueue = async (type: string, data: any) => {
         {
             name: data.name,
             properties: Object.assign(Object.assign({}, options.defaultProperties), data.properties),
-            ver: 2,
-            type: `${type}Data`
+            type: `${type}Data`,
+            ver: 2
         }
     );
     if (!options.batchDelay) {
         await sendTelemetry();
-    }
-    else if (!sendTimeout) {
+    } else if (!sendTimeout) {
         sendTimeout = setTimeout(sendTelemetry, options.batchDelay);
     }
 };

--- a/src/common/analytics.ts
+++ b/src/common/analytics.ts
@@ -14,9 +14,9 @@ const options = {
 let sendTimeout: any = null;
 let telemetryQueue: any = [];
 
-const post = async () => {
+const post = async (data: any) => {
     try {
-        const response = await got.post(apiEndpointHostname, { json: telemetryQueue });
+        const response = await got.post(apiEndpointHostname, { json: data });
 
         console.log(response.body);
     } catch (error) {
@@ -31,8 +31,8 @@ const sendTelemetry = async () => {
     }
 
     try {
-        await post();
-        telemetryQueue = [];
+        const data = telemetryQueue.splice(0);
+        await post(data);
     } catch (err) {
         console.warn('Failed to send telemetry: ', err);
     }

--- a/src/common/analytics.ts
+++ b/src/common/analytics.ts
@@ -17,7 +17,7 @@ let telemetryQueue: any = [];
 const post = async () => {
     try {
         const response = await got.post(apiEndpointHostname, { json: telemetryQueue });
-        telemetryQueue = [];
+
         console.log(response.body);
     } catch (error) {
         console.warn(error.response.body);
@@ -29,9 +29,10 @@ const sendTelemetry = async () => {
         clearTimeout(sendTimeout);
         sendTimeout = null;
     }
-        telemetryQueue = [];
+
     try {
         await post();
+        telemetryQueue = [];
     } catch (err) {
         console.warn('Failed to send telemetry: ', err);
     }

--- a/src/telemetry-api/index.ts
+++ b/src/telemetry-api/index.ts
@@ -1,6 +1,6 @@
 import { AzureFunction, Context, HttpRequest } from '@azure/functions';
 
-import { sendPendingData, trackEvent } from '../common/analytics';
+import { sendPendingData, addToAppInsights } from '../common/analytics';
 
 export const run: AzureFunction = async (context: Context, req: HttpRequest): Promise<void> => {
     context.log('Processing telemetry log request');
@@ -14,7 +14,7 @@ export const run: AzureFunction = async (context: Context, req: HttpRequest): Pr
 
     try {
         for (const telemetry of req.body.data) {
-            trackEvent(telemetry.name, telemetry.properties);
+            addToAppInsights(telemetry.name, telemetry.properties);
         }
 
         await sendPendingData();


### PR DESCRIPTION
Currently, we log telemetry directly to app insights, which automatically logs additional user info like IP address. This change re-routes telemetry calls to our telemetry API that drops all user data and only logs unidentifiable usage data. 