### PR TITLE
Fix: Allow telemetry queue to be directly in request body

### DIFF
--- a/src/telemetry-api/index.ts
+++ b/src/telemetry-api/index.ts
@@ -3,17 +3,22 @@ import { AzureFunction, Context, HttpRequest } from '@azure/functions';
 import { sendPendingData, addToAppInsights } from '../common/analytics';
 
 export const run: AzureFunction = async (context: Context, req: HttpRequest): Promise<void> => {
+    const telemetryQueue = req.body.data || req.body;
+
     context.log('Processing telemetry log request');
 
-    if (!req.body || !req.body.data) {
+    if (!Array.isArray(telemetryQueue)) {
         context.res = {
             body: 'Invalid request',
             status: 400
         };
+        context.done();
+
+        return;
     }
 
     try {
-        for (const telemetry of req.body.data) {
+        for (const telemetry of telemetryQueue) {
             addToAppInsights(telemetry.data.name, telemetry.data.properties, telemetry.data.measurements, new Date(telemetry.time));
         }
 

--- a/src/telemetry-api/index.ts
+++ b/src/telemetry-api/index.ts
@@ -3,7 +3,7 @@ import { AzureFunction, Context, HttpRequest } from '@azure/functions';
 import { sendPendingData, addToAppInsights } from '../common/analytics';
 
 export const run: AzureFunction = async (context: Context, req: HttpRequest): Promise<void> => {
-    const telemetryQueue = req.body.data || req.body;
+    const telemetryQueue = req.body?.data || req.body;
 
     context.log('Processing telemetry log request');
 


### PR DESCRIPTION
Will resolve issues logging telemetry from the current VS Code and browser extensions.